### PR TITLE
Prevent error when evaluating if/else branches

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_autoscaling_group" "this" {
   count = "${var.create_asg}"
 
   name_prefix          = "${coalesce(var.asg_name, var.name)}-"
-  launch_configuration = "${var.create_lc ? element(aws_launch_configuration.this.*.name, 0) : var.launch_configuration}"
+  launch_configuration = "${var.create_lc ? element(concat(aws_launch_configuration.this.*.name, list("")), 0) : var.launch_configuration}"
   vpc_zone_identifier  = ["${var.vpc_zone_identifier}"]
   max_size             = "${var.max_size}"
   min_size             = "${var.min_size}"


### PR DESCRIPTION
HIL (the interpolation language) doesn't lazy evaluate the branches of the if statement yet, so when the user tell to this module to use an existing Launch configuration (and don't create a new one), the execution fails.